### PR TITLE
I've added the basic structure for supporting the Scallop and Haedal …

### DIFF
--- a/bin/arb/src/defi/indexer_searcher.rs
+++ b/bin/arb/src/defi/indexer_searcher.rs
@@ -23,6 +23,8 @@ use dex_indexer::protocols::deepbook_v2::DeepbookV2Adapter;
 use dex_indexer::protocols::flowx_clmm::FlowxCLMMAdapter;
 use dex_indexer::protocols::kriya_amm::KriyaAmmAdapter;
 use dex_indexer::protocols::navi::NaviAdapter;
+use dex_indexer::protocols::scallop_adapter::ScallopAdapter;
+use dex_indexer::protocols::haedal_adapter::HaedalAdapter; // Added HaedalAdapter
 use dex_indexer::protocols::turbos::TurbosAdapter;
 use crate::defi::kriya_clmm::KriyaClmm; // This should point to the refactored KriyaClmm adapter
 
@@ -148,6 +150,18 @@ impl DexSearcher for IndexerDexSearcher {
                         .await
                         .map(|adapter| Box::new(adapter) as Box<dyn ProtocolAdapter>)
                         .map_err(|e| eyre!("TurbosAdapter error for pool {}: {}", pool_data.pool, e))
+                }
+                Protocol::Scallop => {
+                    ScallopAdapter::new(simulator, &pool_data, coin_in_type_for_pool)
+                        .await
+                        .map(|adapter| Box::new(adapter) as Box<dyn ProtocolAdapter>)
+                        .map_err(|e| eyre!("ScallopAdapter error for pool {}: {}", pool_data.pool, e))
+                }
+                Protocol::Haedal => {
+                    HaedalAdapter::new(simulator, &pool_data, coin_in_type_for_pool)
+                        .await
+                        .map(|adapter| Box::new(adapter) as Box<dyn ProtocolAdapter>)
+                        .map_err(|e| eyre!("HaedalAdapter error for pool {}: {}", pool_data.pool, e))
                 }
                 unsupported_protocol => {
                     // tracing::warn!("Skipping unsupported protocol {:?} for pool {}", unsupported_protocol, pool_data.pool);
@@ -287,6 +301,18 @@ impl DexSearcher for IndexerDexSearcher {
                         .await
                         .map(|a| Box::new(a) as Box<dyn ProtocolAdapter>)
                         .map_err(|e| eyre!("TurbosAdapter failed for test path pool {}: {}", pool_info.pool, e))
+                }
+                Protocol::Scallop => {
+                    ScallopAdapter::new(simulator, &pool_info, current_coin_in_type)
+                        .await
+                        .map(|a| Box::new(a) as Box<dyn ProtocolAdapter>)
+                        .map_err(|e| eyre!("ScallopAdapter failed for test path pool {}: {}", pool_info.pool, e))
+                }
+                Protocol::Haedal => {
+                    HaedalAdapter::new(simulator, &pool_info, current_coin_in_type)
+                        .await
+                        .map(|a| Box::new(a) as Box<dyn ProtocolAdapter>)
+                        .map_err(|e| eyre!("HaedalAdapter failed for test path pool {}: {}", pool_info.pool, e))
                 }
                 unsupported_protocol => {
                     return Err(eyre!(

--- a/crates/dex-indexer/src/protocols/haedal_adapter.rs
+++ b/crates/dex-indexer/src/protocols/haedal_adapter.rs
@@ -1,0 +1,239 @@
+// crates/dex-indexer/src/protocols/haedal_adapter.rs
+use std::collections::HashSet;
+use std::sync::Arc;
+use async_trait::async_trait;
+use eyre::{Result, eyre, ensure};
+use move_core_types::annotated_value::MoveStruct;
+use move_core_types::identifier::Identifier;
+use sui_sdk::{SuiClient, rpc_types::SuiEvent};
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    transaction::{Argument, Command, TransactionData},
+    TypeTag, // Added for self.type_params
+};
+use simulator::Simulator;
+
+use crate::protocols::{common_trade_types::{FlashResult, TradeCtx}, ProtocolAdapter, CloneBoxedProtocolAdapter, utils as protocol_utils};
+use crate::types::{Pool as IndexerPool, Protocol as IndexerProtocol, SwapEvent as IndexerSwapEvent};
+use crate::utils::normalize_coin_type;
+
+// TODO: Replace with actual Haedal package ID
+const HAEDAL_PACKAGE_ID_PLACEHOLDER: &str = "0xHAEDAL_PACKAGE_ID_PLACEHOLDER";
+
+#[derive(Clone, Debug)]
+pub struct HaedalAdapter {
+    pub pool_id: ObjectID,
+    pub coin_in_type: String,
+    pub coin_out_type: String,
+    pub type_params: Vec<TypeTag>, // For coin_a, coin_b type tags
+    pub liquidity: u128,           // Actual field name from Haedal pool needed
+    pub simulator: Arc<dyn Simulator>, // Store simulator for potential use
+    // Add any Haedal-specific cached ObjectArgs if applicable
+}
+
+impl HaedalAdapter {
+    pub async fn new(simulator: Arc<dyn Simulator>, pool: &IndexerPool, coin_in_type: &str) -> Result<Self> {
+        ensure!(pool.protocol == IndexerProtocol::Haedal, "Invalid protocol for HaedalAdapter");
+
+        let pool_obj = simulator.get_object(&pool.pool)
+            .await?
+            .ok_or_else(|| eyre!("Haedal pool object {} not found", pool.pool))?;
+
+        let layout = simulator.get_object_layout(&pool.pool)
+            .await?
+            .ok_or_else(|| eyre!("Layout not found for Haedal pool {}", pool.pool))?;
+
+        let move_struct = MoveStruct::simple_deserialize(
+            pool_obj.data.try_as_move().ok_or_eyre("Not a move object")?.contents(),
+            &layout
+        )?;
+
+        // Placeholder logic for type_params and coin_out_type
+        // TODO: Replace with actual Haedal pool structure inspection
+        ensure!(move_struct.type_.type_params.len() >= 2, "Haedal pool type parameters missing coin types");
+        let actual_coin_a_type_tag = move_struct.type_.type_params[0].clone();
+        let actual_coin_b_type_tag = move_struct.type_.type_params[1].clone();
+
+        let actual_coin_a_type = normalize_coin_type(&actual_coin_a_type_tag.to_string());
+        let actual_coin_b_type = normalize_coin_type(&actual_coin_b_type_tag.to_string());
+
+        let normalized_coin_in_type = normalize_coin_type(coin_in_type);
+
+        let (coin_in_type_final, coin_out_type_final, type_params_final) = if actual_coin_a_type == normalized_coin_in_type {
+            (actual_coin_a_type, actual_coin_b_type, vec![actual_coin_a_type_tag, actual_coin_b_type_tag])
+        } else if actual_coin_b_type == normalized_coin_in_type {
+            (actual_coin_b_type, actual_coin_a_type, vec![actual_coin_b_type_tag, actual_coin_a_type_tag])
+        } else {
+            return Err(eyre!("Input coin type {} not found in Haedal pool {} ({}, {})",
+                coin_in_type, pool.pool, actual_coin_a_type, actual_coin_b_type));
+        };
+
+        // TODO: Replace "liquidity_field_placeholder" with actual field name for liquidity
+        let liquidity = protocol_utils::extract_u128_from_move_struct(&move_struct, "liquidity_field_placeholder").unwrap_or(0);
+
+        Ok(Self {
+            pool_id: pool.pool,
+            coin_in_type: coin_in_type_final,
+            coin_out_type: coin_out_type_final,
+            type_params: type_params_final,
+            liquidity,
+            simulator,
+        })
+    }
+}
+
+#[async_trait]
+impl ProtocolAdapter for HaedalAdapter {
+    fn support_flashloan(&self) -> bool {
+        // TODO: Determine if Haedal supports flashloans
+        false
+    }
+
+    async fn extend_flashloan_tx(&self, _ctx: &mut TradeCtx, _amount: u64) -> Result<FlashResult> {
+        eyre::bail!("Flashloan not supported by HaedalAdapter (default or not yet implemented)")
+    }
+
+    async fn extend_repay_tx(&self, _ctx: &mut TradeCtx, _coin: Argument, _flash_res: FlashResult) -> Result<Argument> {
+        eyre::bail!("Flashloan not supported by HaedalAdapter (default or not yet implemented)")
+    }
+
+    async fn extend_trade_tx(&self, ctx: &mut TradeCtx, _sender: SuiAddress, coin_in: Argument, _amount_in: Option<u64>) -> Result<Argument> {
+        // TODO: Replace with actual Haedal swap logic
+        let package_id = ObjectID::from_hex_literal(HAEDAL_PACKAGE_ID_PLACEHOLDER)?;
+        let module_name = Identifier::new("swap_module_placeholder")?;
+        let function_name = Identifier::new("swap_function_placeholder")?;
+
+        // TODO: Build actual arguments for Haedal swap
+        let arguments = vec![
+            ctx.obj_mut(self.pool_id)?,
+            coin_in,
+        ];
+
+        ctx.add_command(Command::move_call(
+            package_id,
+            module_name,
+            function_name,
+            self.type_params.clone(),
+            arguments,
+        ));
+        Ok(Argument::Result(ctx.last_command_idx()))
+    }
+
+    fn coin_in_type(&self) -> String { self.coin_in_type.clone() }
+    fn coin_out_type(&self) -> String { self.coin_out_type.clone() }
+
+    fn protocol(&self) -> IndexerProtocol {
+        IndexerProtocol::Haedal
+    }
+
+    fn liquidity(&self) -> u128 { self.liquidity }
+    fn object_id(&self) -> ObjectID { self.pool_id }
+
+    fn flip(&mut self) {
+        std::mem::swap(&mut self.coin_in_type, &mut self.coin_out_type);
+        if self.type_params.len() == 2 {
+            self.type_params.swap(0, 1);
+        }
+    }
+
+    fn is_a2b(&self) -> bool {
+        if let Some(first_type_param) = self.type_params.get(0) {
+            normalize_coin_type(&first_type_param.to_string()) == self.coin_in_type
+        } else {
+            true
+        }
+    }
+
+    async fn swap_tx(&self, sender: SuiAddress, recipient: SuiAddress, amount_in: u64) -> Result<TransactionData> {
+        // TODO: Replace with actual Haedal swap_tx logic
+        let sui_client = SuiClient::new_for_testing(None).await?;
+
+        let gas_coins = protocol_utils::get_gas_coins_for_testing(&sui_client, sender, None).await?;
+        let gas_price = sui_client.reference_gas_price().await?;
+
+        let mut ctx = TradeCtx::default();
+        let coin_in_obj = protocol_utils::get_coin_object_arg_for_testing(&sui_client, sender, &self.coin_in_type, amount_in, &mut ctx).await?;
+
+        let coin_out_arg = self.extend_trade_tx(&mut ctx, sender, coin_in_obj, Some(amount_in)).await?;
+        ctx.transfer_arg(recipient, coin_out_arg);
+
+        Ok(TransactionData::new_programmable(
+            sender,
+            gas_coins,
+            ctx.into_programmable_transaction(),
+            protocol_utils::DEFAULT_GAS_BUDGET,
+            gas_price,
+        ))
+    }
+
+    async fn parse_pool_created_event(&self, event: &SuiEvent, sui_client: &SuiClient) -> Result<IndexerPool> {
+        // TODO: Replace with actual Haedal PoolCreatedEvent parsing
+        let expected_event_type = format!("{}::pool_events::PoolCreatedEventPlaceholder", HAEDAL_PACKAGE_ID_PLACEHOLDER);
+        ensure!(event.type_.to_string() == expected_event_type, "Event type mismatch for Haedal PoolCreatedEvent");
+
+        let pool_id_str = event.parsed_json.get("pool_id").and_then(|v| v.as_str()).ok_or_eyre("Missing pool_id in event")?;
+        let pool_id = ObjectID::from_hex_literal(pool_id_str)?;
+
+        let token_a_type_str = event.parsed_json.get("token_a_type").and_then(|v| v.as_str()).ok_or_eyre("Missing token_a_type in event")?;
+        let token_b_type_str = event.parsed_json.get("token_b_type").and_then(|v| v.as_str()).ok_or_eyre("Missing token_b_type in event")?;
+
+        let (decimals_a, decimals_b) = protocol_utils::get_coin_decimals_pair(sui_client, token_a_type_str, token_b_type_str).await?;
+
+        Ok(IndexerPool {
+            pool: pool_id,
+            protocol: IndexerProtocol::Haedal,
+            token0: token_a_type_str.to_string(),
+            token1: token_b_type_str.to_string(),
+            token0_decimals: decimals_a,
+            token1_decimals: decimals_b,
+            ..Default::default()
+        })
+    }
+
+    async fn parse_swap_event(&self, event: &SuiEvent, _simulator: Arc<dyn Simulator>) -> Result<IndexerSwapEvent> {
+        // TODO: Replace with actual Haedal SwapEvent parsing
+        let expected_event_type = format!("{}::pool_events::SwapEventPlaceholder", HAEDAL_PACKAGE_ID_PLACEHOLDER);
+        ensure!(event.type_.to_string() == expected_event_type, "Event type mismatch for Haedal SwapEvent");
+
+        let pool_id_str = event.parsed_json.get("pool_id").and_then(|v| v.as_str()).ok_or_eyre("Missing pool_id in event")?;
+        let pool_id = ObjectID::from_hex_literal(pool_id_str)?;
+
+        let input_amount_str = event.parsed_json.get("input_amount").and_then(|v| v.as_str()).ok_or_eyre("Missing input_amount")?;
+        let input_amount = input_amount_str.parse::<u64>()?;
+
+        let output_amount_str = event.parsed_json.get("output_amount").and_then(|v| v.as_str()).ok_or_eyre("Missing output_amount")?;
+        let output_amount = output_amount_str.parse::<u64>()?;
+
+        let input_coin_type = event.parsed_json.get("input_coin_type").and_then(|v| v.as_str()).ok_or_eyre("Missing input_coin_type")?.to_string();
+        let output_coin_type = event.parsed_json.get("output_coin_type").and_then(|v| v.as_str()).ok_or_eyre("Missing output_coin_type")?.to_string();
+
+        Ok(IndexerSwapEvent {
+            pool_id,
+            input_amount,
+            output_amount,
+            a_to_b: true, // TODO: Determine direction
+            sender: event.sender,
+            active_liquidity: None,
+            protocol: IndexerProtocol::Haedal,
+            coin_in_type: input_coin_type,
+            coin_out_type: output_coin_type,
+            timestamp_ms: event.timestamp_ms.unwrap_or(0),
+            tx_digest: event.id.tx_digest,
+            ..Default::default()
+        })
+    }
+
+    async fn get_related_object_ids(&self) -> Result<HashSet<String>> {
+        Ok(HashSet::from([HAEDAL_PACKAGE_ID_PLACEHOLDER.to_string()]))
+    }
+
+    async fn get_pool_children_ids(&self, _pool: &IndexerPool, _sui_client: &SuiClient) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
+impl CloneBoxedProtocolAdapter for HaedalAdapter {
+    fn clone_boxed(&self) -> Box<dyn ProtocolAdapter> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/dex-indexer/src/protocols/mod.rs
+++ b/crates/dex-indexer/src/protocols/mod.rs
@@ -1,6 +1,8 @@
 pub mod aftermath_adapter;
 pub mod cetus_adapter;
-pub mod common_trade_types; // Added new module
+pub mod haedal_adapter; // Newly added
+pub mod scallop_adapter;
+pub mod common_trade_types;
 pub mod utils;
 
 use std::{collections::HashSet, sync::Arc};

--- a/crates/dex-indexer/src/protocols/scallop_adapter.rs
+++ b/crates/dex-indexer/src/protocols/scallop_adapter.rs
@@ -1,0 +1,257 @@
+// crates/dex-indexer/src/protocols/scallop_adapter.rs
+use std::collections::HashSet;
+use std::sync::Arc;
+use async_trait::async_trait;
+use eyre::{Result, eyre, ensure};
+use move_core_types::annotated_value::MoveStruct;
+use move_core_types::identifier::Identifier;
+use sui_sdk::{SuiClient, rpc_types::SuiEvent};
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    transaction::{Argument, Command, TransactionData},
+    TypeTag, // Added for self.type_params
+};
+use simulator::Simulator;
+
+use crate::protocols::{common_trade_types::{FlashResult, TradeCtx}, ProtocolAdapter, CloneBoxedProtocolAdapter, utils as protocol_utils}; // Added protocol_utils
+use crate::types::{Pool as IndexerPool, Protocol as IndexerProtocol, SwapEvent as IndexerSwapEvent};
+use crate::utils::normalize_coin_type; // Added normalize_coin_type
+
+// TODO: Replace with actual Scallop package ID
+const SCALLOP_PACKAGE_ID_PLACEHOLDER: &str = "0xSCALLOP_PACKAGE_ID_PLACEHOLDER";
+
+#[derive(Clone, Debug)]
+pub struct ScallopAdapter {
+    pub pool_id: ObjectID,
+    pub coin_in_type: String,
+    pub coin_out_type: String,
+    pub type_params: Vec<TypeTag>, // For coin_a, coin_b type tags
+    pub liquidity: u128,           // Actual field name from Scallop pool needed
+    pub simulator: Arc<dyn Simulator>, // Store simulator for potential use
+    // Add any Scallop-specific cached ObjectArgs if needed
+}
+
+impl ScallopAdapter {
+    pub async fn new(simulator: Arc<dyn Simulator>, pool: &IndexerPool, coin_in_type: &str) -> Result<Self> {
+        ensure!(pool.protocol == IndexerProtocol::Scallop, "Invalid protocol for ScallopAdapter");
+
+        let pool_obj = simulator.get_object(&pool.pool)
+            .await?
+            .ok_or_else(|| eyre!("Scallop pool object {} not found", pool.pool))?;
+
+        let layout = simulator.get_object_layout(&pool.pool)
+            .await?
+            .ok_or_else(|| eyre!("Layout not found for Scallop pool {}", pool.pool))?;
+
+        let move_struct = MoveStruct::simple_deserialize(
+            pool_obj.data.try_as_move().ok_or_eyre("Not a move object")?.contents(),
+            &layout
+        )?;
+
+        // Placeholder logic for type_params and coin_out_type
+        // TODO: Replace with actual Scallop pool structure inspection
+        ensure!(move_struct.type_.type_params.len() >= 2, "Scallop pool type parameters missing coin types");
+        let actual_coin_a_type_tag = move_struct.type_.type_params[0].clone();
+        let actual_coin_b_type_tag = move_struct.type_.type_params[1].clone();
+
+        let actual_coin_a_type = normalize_coin_type(&actual_coin_a_type_tag.to_string());
+        let actual_coin_b_type = normalize_coin_type(&actual_coin_b_type_tag.to_string());
+
+        let normalized_coin_in_type = normalize_coin_type(coin_in_type);
+
+        let (coin_in_type_final, coin_out_type_final, type_params_final) = if actual_coin_a_type == normalized_coin_in_type {
+            (actual_coin_a_type, actual_coin_b_type, vec![actual_coin_a_type_tag, actual_coin_b_type_tag])
+        } else if actual_coin_b_type == normalized_coin_in_type {
+            (actual_coin_b_type, actual_coin_a_type, vec![actual_coin_b_type_tag, actual_coin_a_type_tag])
+        } else {
+            return Err(eyre!("Input coin type {} not found in Scallop pool {} ({}, {})",
+                coin_in_type, pool.pool, actual_coin_a_type, actual_coin_b_type));
+        };
+
+        // TODO: Replace "liquidity_field_placeholder" with actual field name for liquidity
+        let liquidity = protocol_utils::extract_u128_from_move_struct(&move_struct, "liquidity_field_placeholder").unwrap_or(0);
+
+        Ok(Self {
+            pool_id: pool.pool,
+            coin_in_type: coin_in_type_final,
+            coin_out_type: coin_out_type_final,
+            type_params: type_params_final,
+            liquidity,
+            simulator,
+        })
+    }
+}
+
+#[async_trait]
+impl ProtocolAdapter for ScallopAdapter {
+    fn support_flashloan(&self) -> bool {
+        // TODO: Determine if Scallop supports flashloans
+        false
+    }
+
+    async fn extend_flashloan_tx(&self, _ctx: &mut TradeCtx, _amount: u64) -> Result<FlashResult> {
+        eyre::bail!("Flashloan not supported by ScallopAdapter (default or not yet implemented)")
+    }
+
+    async fn extend_repay_tx(&self, _ctx: &mut TradeCtx, _coin: Argument, _flash_res: FlashResult) -> Result<Argument> {
+        eyre::bail!("Flashloan not supported by ScallopAdapter (default or not yet implemented)")
+    }
+
+    async fn extend_trade_tx(&self, ctx: &mut TradeCtx, _sender: SuiAddress, coin_in: Argument, _amount_in: Option<u64>) -> Result<Argument> {
+        // TODO: Replace with actual Scallop swap logic
+        let package_id = ObjectID::from_hex_literal(SCALLOP_PACKAGE_ID_PLACEHOLDER)?;
+        let module_name = Identifier::new("swap_module_placeholder")?;
+        let function_name = Identifier::new("swap_function_placeholder")?;
+
+        // TODO: Build actual arguments for Scallop swap
+        // e.g. pool object, coin_in, amount_in (if Some), slippage, etc.
+        let arguments = vec![
+            ctx.obj_mut(self.pool_id)?, // Assuming pool object is mutable
+            coin_in,
+            // Argument::Constant(...) for amount_in if needed and not part of coin_in
+        ];
+
+        ctx.add_command(Command::move_call(
+            package_id,
+            module_name,
+            function_name,
+            self.type_params.clone(), // Assuming type_params are CoinA, CoinB for the swap
+            arguments,
+        ));
+        Ok(Argument::Result(ctx.last_command_idx()))
+    }
+
+    fn coin_in_type(&self) -> String { self.coin_in_type.clone() }
+    fn coin_out_type(&self) -> String { self.coin_out_type.clone() }
+
+    fn protocol(&self) -> IndexerProtocol {
+        // This will require adding Scallop to the IndexerProtocol enum in dex_indexer/src/types.rs
+        // For now, if it doesn't exist, this won't compile. Let's assume it will be added.
+        IndexerProtocol::Scallop
+    }
+
+    fn liquidity(&self) -> u128 { self.liquidity }
+    fn object_id(&self) -> ObjectID { self.pool_id }
+
+    fn flip(&mut self) {
+        std::mem::swap(&mut self.coin_in_type, &mut self.coin_out_type);
+        // Also swap type_params if they are ordered (CoinA, CoinB)
+        if self.type_params.len() == 2 {
+            self.type_params.swap(0, 1);
+        }
+    }
+
+    fn is_a2b(&self) -> bool {
+        // Placeholder: Assumes coin_in_type is "token A" if it matches the first type_param.
+        // This needs to be consistent with how Scallop orders tokens or how `new` orients them.
+        if let Some(first_type_param) = self.type_params.get(0) {
+            normalize_coin_type(&first_type_param.to_string()) == self.coin_in_type
+        } else {
+            true // Default or error, should not happen with proper type_params
+        }
+    }
+
+    async fn swap_tx(&self, sender: SuiAddress, recipient: SuiAddress, amount_in: u64) -> Result<TransactionData> {
+        // TODO: Replace with actual Scallop swap_tx logic
+        // This is a simplified version, real implementation might need more details
+
+        // For now, using a test client. In a real scenario, SuiClient might be part of the adapter or passed in.
+        let sui_client = SuiClient::new_for_testing(None).await?; // Placeholder
+
+        let gas_coins = protocol_utils::get_gas_coins_for_testing(&sui_client, sender, None).await?;
+        let gas_price = sui_client.reference_gas_price().await?;
+
+        let mut ctx = TradeCtx::default();
+        let coin_in_obj = protocol_utils::get_coin_object_arg_for_testing(&sui_client, sender, &self.coin_in_type, amount_in, &mut ctx).await?;
+
+        let coin_out_arg = self.extend_trade_tx(&mut ctx, sender, coin_in_obj, Some(amount_in)).await?;
+        ctx.transfer_arg(recipient, coin_out_arg);
+
+        Ok(TransactionData::new_programmable(
+            sender,
+            gas_coins,
+            ctx.into_programmable_transaction(),
+            protocol_utils::DEFAULT_GAS_BUDGET, // Placeholder for gas budget
+            gas_price,
+        ))
+    }
+
+    async fn parse_pool_created_event(&self, event: &SuiEvent, sui_client: &SuiClient) -> Result<IndexerPool> {
+        // TODO: Replace with actual Scallop PoolCreatedEvent parsing
+        let expected_event_type = format!("{}::pool_events::PoolCreatedEventPlaceholder", SCALLOP_PACKAGE_ID_PLACEHOLDER);
+        ensure!(event.type_.to_string() == expected_event_type, "Event type mismatch for Scallop PoolCreatedEvent");
+
+        let pool_id_str = event.parsed_json.get("pool_id").and_then(|v| v.as_str()).ok_or_eyre("Missing pool_id in event")?;
+        let pool_id = ObjectID::from_hex_literal(pool_id_str)?;
+
+        let token_a_type_str = event.parsed_json.get("token_a_type").and_then(|v| v.as_str()).ok_or_eyre("Missing token_a_type in event")?;
+        let token_b_type_str = event.parsed_json.get("token_b_type").and_then(|v| v.as_str()).ok_or_eyre("Missing token_b_type in event")?;
+
+        let (decimals_a, decimals_b) = protocol_utils::get_coin_decimals_pair(sui_client, token_a_type_str, token_b_type_str).await?;
+
+        Ok(IndexerPool {
+            pool: pool_id,
+            protocol: IndexerProtocol::Scallop, // Assuming Scallop variant exists
+            token0: token_a_type_str.to_string(),
+            token1: token_b_type_str.to_string(),
+            token0_decimals: decimals_a,
+            token1_decimals: decimals_b,
+            // Add other fields like fee, etc., if available from event or default
+            ..Default::default()
+        })
+    }
+
+    async fn parse_swap_event(&self, event: &SuiEvent, _simulator: Arc<dyn Simulator>) -> Result<IndexerSwapEvent> {
+        // TODO: Replace with actual Scallop SwapEvent parsing
+        let expected_event_type = format!("{}::pool_events::SwapEventPlaceholder", SCALLOP_PACKAGE_ID_PLACEHOLDER);
+        ensure!(event.type_.to_string() == expected_event_type, "Event type mismatch for Scallop SwapEvent");
+
+        let pool_id_str = event.parsed_json.get("pool_id").and_then(|v| v.as_str()).ok_or_eyre("Missing pool_id in event")?;
+        let pool_id = ObjectID::from_hex_literal(pool_id_str)?;
+
+        let input_amount_str = event.parsed_json.get("input_amount").and_then(|v| v.as_str()).ok_or_eyre("Missing input_amount")?;
+        let input_amount = input_amount_str.parse::<u64>()?;
+
+        let output_amount_str = event.parsed_json.get("output_amount").and_then(|v| v.as_str()).ok_or_eyre("Missing output_amount")?;
+        let output_amount = output_amount_str.parse::<u64>()?;
+
+        let input_coin_type = event.parsed_json.get("input_coin_type").and_then(|v| v.as_str()).ok_or_eyre("Missing input_coin_type")?.to_string();
+        let output_coin_type = event.parsed_json.get("output_coin_type").and_then(|v| v.as_str()).ok_or_eyre("Missing output_coin_type")?.to_string();
+
+        // Placeholder for other fields
+        Ok(IndexerSwapEvent {
+            pool_id,
+            input_amount,
+            output_amount,
+            a_to_b: true, // TODO: Determine direction from event data
+            sender: event.sender,
+            active_liquidity: None, // TODO: Parse if available
+            protocol: IndexerProtocol::Scallop,
+            coin_in_type: input_coin_type,
+            coin_out_type: output_coin_type,
+            timestamp_ms: event.timestamp_ms.unwrap_or(0),
+            tx_digest: event.id.tx_digest,
+            // ... other fields as necessary
+            ..Default::default()
+        })
+    }
+
+    async fn get_related_object_ids(&self) -> Result<HashSet<String>> {
+        // TODO: Add any other relevant static ObjectIDs for Scallop if any
+        Ok(HashSet::from([SCALLOP_PACKAGE_ID_PLACEHOLDER.to_string()]))
+    }
+
+    async fn get_pool_children_ids(&self, pool: &IndexerPool, sui_client: &SuiClient) -> Result<Vec<String>> {
+        // TODO: Determine if Scallop pools have children objects that need indexing (e.g., positions in a CLMM)
+        // If Scallop is a simple AMM-style pool, it might not have children.
+        // If it does, use something like:
+        // protocol_utils::get_children_ids_from_dynamic_fields(pool.pool, sui_client).await
+        Ok(Vec::new()) // Defaulting to no children
+    }
+}
+
+impl CloneBoxedProtocolAdapter for ScallopAdapter {
+    fn clone_boxed(&self) -> Box<dyn ProtocolAdapter> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/dex-indexer/src/types.rs
+++ b/crates/dex-indexer/src/types.rs
@@ -265,6 +265,8 @@ pub enum Protocol {
     Abex,
     BabySwap,
     Navi,
+    Scallop,
+    Haedal, // Added Haedal
 }
 
 impl fmt::Display for Protocol {
@@ -286,6 +288,8 @@ impl fmt::Display for Protocol {
             Protocol::Abex => write!(f, "abex"),
             Protocol::BabySwap => write!(f, "babyswap"),
             Protocol::Navi => write!(f, "navi"),
+            Protocol::Scallop => write!(f, "scallop"),
+            Protocol::Haedal => write!(f, "haedal"), // Added Haedal
         }
     }
 }
@@ -311,6 +315,8 @@ impl TryFrom<&str> for Protocol {
             "abex" => Ok(Protocol::Abex),
             "babyswap" => Ok(Protocol::BabySwap),
             "navi" => Ok(Protocol::Navi),
+            "scallop" => Ok(Protocol::Scallop),
+            "haedal" => Ok(Protocol::Haedal), // Added Haedal
             _ => bail!("Unsupported protocol: {}", value),
         }
     }


### PR DESCRIPTION
…DeFi protocols. This includes creating adapter files, defining placeholder implementations for the `ProtocolAdapter` trait, and integrating these into your existing system.

**Key Changes:**

1.  **Scallop Protocol Scaffolding:**
    *   I created `crates/dex-indexer/src/protocols/scallop_adapter.rs`.
    *   I defined the `ScallopAdapter` struct with placeholder fields and a basic `new` constructor outline.
    *   I implemented `ProtocolAdapter` for `ScallopAdapter` with placeholder logic. Core functionalities like `extend_trade_tx` and event parsing currently return "not yet implemented" errors.
    *   I added `// TODO:` comments and placeholder constants (e.g., `0xSCALLOP_PACKAGE_ID_PLACEHOLDER`) to mark areas requiring Scallop-specific details.
    *   I registered the `scallop_adapter` module in `crates/dex-indexer/src/protocols/mod.rs`.

2.  **Haedal Protocol Scaffolding:**
    *   I created `crates/dex-indexer/src/protocols/haedal_adapter.rs`.
    *   I defined the `HaedalAdapter` struct similarly with placeholder fields and constructor outline.
    *   I implemented `ProtocolAdapter` for `HaedalAdapter` with placeholder logic, similar to Scallop.
    *   I added `// TODO:` comments and placeholder constants (e.g., `0xHAEDAL_PACKAGE_ID_PLACEHOLDER`).
    *   I registered the `haedal_adapter` module in `crates/dex-indexer/src/protocols/mod.rs`.

3.  **Enum Updates (`crates/dex-indexer/src/types.rs`):**
    *   I added `Scallop` and `Haedal` variants to the `Protocol` enum.
    *   I updated `fmt::Display` and `TryFrom<&str>` implementations to support these new protocols.

4.  **Integration with Arbitrage Bot (`bin/arb/src/defi/indexer_searcher.rs`):**
    *   I imported `ScallopAdapter` and `HaedalAdapter`.
    *   I extended `match` statements in `find_dexes` and `find_test_path` to recognize `Protocol::Scallop` and `Protocol::Haedal`, and to attempt instantiation of their respective adapters.

**Important Note:**
The Scallop and Haedal adapters are currently **placeholders only**. They provide the necessary structure but lack the actual implementation details for these protocols. Further work is required to fill in the `// TODO:` sections with correct package IDs, module/function names, event types, and logic specific to Scallop and Haedal to make them functional.

This lays the groundwork for future full implementation of these protocols as you requested.